### PR TITLE
Remove LC, add IG+ modes

### DIFF
--- a/cogs/pug.py
+++ b/cogs/pug.py
@@ -51,7 +51,8 @@ Mode = collections.namedtuple('Mode', 'maxPlayers friendlyFireScale mutators')
 MODE_CONFIG = {
     'stdAS': Mode(20, 0, None),
     'proAS': Mode(20, 100, None),
-    'lcAS': Mode(20, 0, 'LCWeapons_0025uta.LCMutator'),
+    'ASplus': Mode(20, 0, 'LeagueAS-SP.ASPlus'),
+    'proASplus': Mode(20, 100, 'LeagueAS-SP.ASPlus'),
     'iAS': Mode(20, 0, 'LeagueAS-SP.iAS'),
     'ZPiAS': Mode(20, 0, 'ZeroPingPlus103.ColorAccuGib')
 }


### PR DESCRIPTION
- Introduced a "loader" mutator in LeagueAS-SP which can be updated independently of the bot to point to the latest CI build of our IG+ fork... Bot just needs to send the loader mutator with a game setup to start it up.